### PR TITLE
Add option --only-headers to support passing of header structs only

### DIFF
--- a/p4-traffictool.sh
+++ b/p4-traffictool.sh
@@ -6,7 +6,7 @@
 #   3 p4 compilation error
 
 usage(){
-    echo "Usage: p4-traffictool.sh [-h|--help] [-p4 <path to p4 source>] [-json <path to json description>] [--std {p4-14|p4-16}] [-o <path to destination dir>] [--scapy] [--wireshark] [--moongen] [--pcpp] [--debug]"
+    echo "Usage: p4-traffictool.sh [-h|--help] [-p4 <path to p4 source>] [-json <path to json description>] [--std {p4-14|p4-16}] [--no-body] [-o <path to destination dir>] [--scapy] [--wireshark] [--moongen] [--pcpp] [--debug]"
     exit $1
 }
 
@@ -14,6 +14,7 @@ print_arguments(){
     echo -e "------------------------------------"
     echo "P4_SOURCE $P4_SOURCE"
     echo "JSONSOURCE $JSONSOURCE"
+    echo "NO BODY $NO_BODY"
     echo "SCAPY $SCAPY"
     echo "WIRESHARK $WIRESHARK"
     echo "PCAPPLUSPLUS $PCAPPLUSPLUS"
@@ -35,6 +36,7 @@ fi
 JSON_DETECT=false
 P4_DETECT=false
 OUT_DETECT=false
+NO_BODY=false
 SCAPY=false
 WIRESHARK=false
 MOONGEN=false
@@ -91,6 +93,10 @@ while test $# -gt 0; do
                 usage 2
             fi
             ;;
+	--no-body)
+	    shift
+	    NO_BODY=true
+	    ;;
         --scapy)
             shift
             SCAPY=true
@@ -176,6 +182,8 @@ if [[ "$SCAPY" = false  &&  "$MOONGEN" = false &&  "$PCAPPLUSPLUS" = false &&  "
 fi
 
 if [ "$JSON_DETECT" = false ]; then
+
+
     # creates a temp folder with timestamp to hold json script and compiled binaries
     foldername="`date +%Y%m%d%H%M%S`";
     foldername="tempfolder_$foldername"
@@ -183,6 +191,17 @@ if [ "$JSON_DETECT" = false ]; then
     jsonname="${jsonname%.*}.json"
     mkdir $foldername
     cd $foldername
+
+    # creates a tempfile which adds the headers along with stub functions for v1 model 
+    if [ "$NO_BODY" = true ]; then
+	echo "Adding p4 source file to template to create p4 source file."
+	p4filename=$(basename -- "$P4_SOURCE")
+	tempcommand="awk 'FNR==8{system(\"cat $P4_SOURCE\")} 1' ../templates/template.p4 > $p4filename"
+	#echo $tempcommand
+	eval $tempcommand
+	tempp4source=$P4_SOURCE
+	P4_SOURCE=$p4filename
+    fi
 
     # p4 source compilation
     echo -e "----------------------------------\nCompiling p4 source ..."
@@ -203,7 +222,13 @@ if [ "$JSON_DETECT" = false ]; then
         echo "Compilation successful with p4c-bm2-ss"
     fi
     echo -e "------------------------------------\n"
+   
+
+    if [ "$NO_BODY" = true ]; then
+	P4_SOURCE=$tempp4source
+    fi
     
+ 
     JSONSOURCE=$(find . -name "*.json" -type f)
     JSONSOURCE=$(realpath $JSONSOURCE)
     cd ..

--- a/p4-traffictool.sh
+++ b/p4-traffictool.sh
@@ -6,7 +6,7 @@
 #   3 p4 compilation error
 
 usage(){
-    echo "Usage: p4-traffictool.sh [-h|--help] [-p4 <path to p4 source>] [-json <path to json description>] [--std {p4-14|p4-16}] [--no-body] [-o <path to destination dir>] [--scapy] [--wireshark] [--moongen] [--pcpp] [--debug]"
+    echo "Usage: p4-traffictool.sh [-h|--help] [-p4 <path to p4 source>] [-json <path to json description>] [--std {p4-14|p4-16}] [--only-headers] [-o <path to destination dir>] [--scapy] [--wireshark] [--moongen] [--pcpp] [--debug]"
     exit $1
 }
 
@@ -14,7 +14,7 @@ print_arguments(){
     echo -e "------------------------------------"
     echo "P4_SOURCE $P4_SOURCE"
     echo "JSONSOURCE $JSONSOURCE"
-    echo "NO BODY $NO_BODY"
+    echo "ONLY HEADERS $ONLY_HEADERS"
     echo "SCAPY $SCAPY"
     echo "WIRESHARK $WIRESHARK"
     echo "PCAPPLUSPLUS $PCAPPLUSPLUS"
@@ -36,7 +36,7 @@ fi
 JSON_DETECT=false
 P4_DETECT=false
 OUT_DETECT=false
-NO_BODY=false
+ONLY_HEADERS=false
 SCAPY=false
 WIRESHARK=false
 MOONGEN=false
@@ -93,9 +93,9 @@ while test $# -gt 0; do
                 usage 2
             fi
             ;;
-	--no-body)
+	--only-headers)
 	    shift
-	    NO_BODY=true
+	    ONLY_HEADERS=true
 	    ;;
         --scapy)
             shift
@@ -193,7 +193,7 @@ if [ "$JSON_DETECT" = false ]; then
     cd $foldername
 
     # creates a tempfile which adds the headers along with stub functions for v1 model 
-    if [ "$NO_BODY" = true ]; then
+    if [ "$ONLY_HEADERS" = true ]; then
 	echo "Adding p4 source file to template to create p4 source file."
 	p4filename=$(basename -- "$P4_SOURCE")
 	tempcommand="awk 'FNR==8{system(\"cat $P4_SOURCE\")} 1' ../templates/template.p4 > $p4filename"
@@ -224,7 +224,7 @@ if [ "$JSON_DETECT" = false ]; then
     echo -e "------------------------------------\n"
    
 
-    if [ "$NO_BODY" = true ]; then
+    if [ "$ONLY_HEADERS" = true ]; then
 	P4_SOURCE=$tempp4source
     fi
     

--- a/templates/template.p4
+++ b/templates/template.p4
@@ -1,0 +1,91 @@
+#include <core.p4>
+#include <v1model.p4>
+
+/*************************************************************************
+*********************** H E A D E R S  ***********************************
+*************************************************************************/
+
+
+
+struct metadata {
+
+}
+
+
+/**********************PARSER******************************/
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition accept;
+    }
+
+}
+
+/*************************************************************************
+************   C H E C K S U M    V E R I F I C A T I O N   *************
+*************************************************************************/
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+    apply {  }
+}
+
+
+/*************************************************************************
+**************  I N G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+
+    
+    apply {
+        
+    }
+}
+
+/*************************************************************************
+****************  E G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+/*************************************************************************
+*************   C H E C K S U M    C O M P U T A T I O N   **************
+*************************************************************************/
+
+control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
+     apply {
+
+    }
+}
+
+/*************************************************************************
+***********************  D E P A R S E R  *******************************
+*************************************************************************/
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+/*************************************************************************
+***********************  S W I T C H  *******************************
+*************************************************************************/
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;


### PR DESCRIPTION
### Completed
- `--only-headers` allows users to pass only header structs in a p4 file instead of a fully compiling p4 source code
- header structs are appended to a template p4 file to produce a p4c compilable code
- no bindings will be generated in the output files since the template does not contain any parser logic

### Remaining
- remove relative path for template file
- auto-detect/auto-generate `struct headers`